### PR TITLE
CON-2417: the request manager now rejects responses with a custom error

### DIFF
--- a/subscriptions/app.js
+++ b/subscriptions/app.js
@@ -39,5 +39,12 @@ export default function app(subscribe) {
     event.addCallback('viewWillAppear', hideLegacyNavigation);
     event.addCallback('viewWillDisappear', showLegacyNavigation);
     event.addCallback('showPreviousTab', showPreviousTab);
+
+    /**
+     * The following events are sometimes sent by the app, but don't need to be handled right now.
+     * To avoid console warnings from the event system, empty handlers are registered here.
+     */
+    event.addCallback('viewDidAppear', () => {});
+    event.addCallback('pageInsetsChanged', () => {});
   });
 }

--- a/subscriptions/user.js
+++ b/subscriptions/user.js
@@ -38,9 +38,8 @@ export default function user(subscribe) {
   });
 
   subscribe(appDidStart$, ({ dispatch }) => {
-    registerEvents(['viewDidAppear', 'userLoggedIn']);
+    registerEvents(['userLoggedIn']);
 
-    event.addCallback('viewDidAppear', () => dispatch(getUser()));
     event.addCallback('userLoggedIn', () => dispatch(successLogin()));
   });
 }


### PR DESCRIPTION
- the cart loading state is now be resetted when cart related requests are rejected by the request manager
- removed an unnecessary fetching of the cart at app start