### PR TITLE
CON-2651: deactivated openPage animation

### DIFF
--- a/components/Router/helpers/parsed-link/actions.js
+++ b/components/Router/helpers/parsed-link/actions.js
@@ -68,6 +68,7 @@ const legacyLink = (options) => {
       src: `sgapi:${options.url.substring(1)}`,
       previewSrc: 'sgapi:page_preview',
       targetTab: options.targetTab,
+      animated: false,
       navigationBarParams: {
         type: options.navigationType ? options.navigationType : 'default',
         leftButtonCallback: options.backCallback ? options.backCallback : '',


### PR DESCRIPTION
- the legacy page now opens without animation to avoid visible root
pages of tabs