### PR TITLE
CON-2878: Added logic to handle links to the app scanner

### DIFF
--- a/components/Router/helpers/parsed-link/actions.js
+++ b/components/Router/helpers/parsed-link/actions.js
@@ -26,6 +26,13 @@ const native = (url) => {
 const pushNotification = () => {};
 
 /**
+ * The eventLink handler is intended to be used for situations where no route change happens.
+ * In that case only the openLink event is triggered and the related logic runs within
+ * steam subscriptions.
+ */
+const eventLink = () => {};
+
+/**
  * External link that should be opened in the in app browser.
  * @param {string} url Url that should be opened.
  */
@@ -115,4 +122,5 @@ export default {
   legacyLink,
   reactRouter,
   pushNotification,
+  eventLink,
 };

--- a/components/Router/helpers/parsed-link/options.js
+++ b/components/Router/helpers/parsed-link/options.js
@@ -7,6 +7,7 @@
 
 import {
   INDEX_PATH,
+  SCANNER_PATH,
 } from '../../../../constants/RoutePaths';
 
 /**
@@ -140,7 +141,12 @@ function getSimpleLinkParserOptions(path, queryParams, url) {
         url: '/register/default',
       });
       break;
-
+    case 'scanner':
+      this.addLinkAction('eventLink', {
+        url: SCANNER_PATH,
+        queryParams,
+      });
+      break;
     default:
       this.addLinkAction('reactRouter', {
         url,

--- a/constants/RoutePaths.js
+++ b/constants/RoutePaths.js
@@ -11,6 +11,8 @@ export const LOGIN_PATH = '/login';
 export const REGISTER_PATH = '/register';
 export const CHECKOUT_PATH = '/checkout';
 
+export const SCANNER_PATH = '/scanner';
+
 /**
  * Our current existing Deeplinks and Pushs use '/index' for the homepage
  * @type {string}

--- a/streams/history.js
+++ b/streams/history.js
@@ -7,7 +7,10 @@
 
 import { OPEN_LINK, UPDATE_HISTORY } from '../constants/ActionTypes';
 import { getHistoryPathname, getHistoryAction } from '../selectors/history';
-import { REGISTER_PATH } from '../constants/RoutePaths';
+import {
+  REGISTER_PATH,
+  SCANNER_PATH,
+} from '../constants/RoutePaths';
 import { main$ } from './main';
 
 /**
@@ -101,3 +104,9 @@ export const openedRegisterLink$ = openedLink$
     action.options &&
     action.options.url &&
     action.options.url === REGISTER_PATH);
+
+export const openedScannerLink$ = openedLink$
+  .filter(({ action }) =>
+    action.options &&
+    action.options.url &&
+    action.options.url === SCANNER_PATH);

--- a/subscriptions/scanner.js
+++ b/subscriptions/scanner.js
@@ -1,0 +1,27 @@
+import ScannerManager from '@shopgate/pwa-core/classes/ScannerManager';
+import { openedScannerLink$ } from '../streams/history';
+
+/**
+ * App Scanner subscriptions.
+ * @param {Function} subscribe The subscribe function.
+ */
+export default function scanner(subscribe) {
+  /**
+   * Gets triggered when the app starts.
+   */
+  subscribe(openedScannerLink$, () => {
+    /**
+     * The handler to process scanned content from the scanner.
+     * @param {Object} data The scanned data
+     * @param {string} data.format The format of the scanned content.
+     * @param {string} data.code The code that has been scanned.
+     */
+    const scanHandler = async () => {
+      // TODO Add scan logic here
+    };
+
+    const scannerManager = new ScannerManager();
+    scannerManager.registerScanHandler(scanHandler);
+    scannerManager.openScanner();
+  });
+}


### PR DESCRIPTION
- introduced new link type to the parsed link helper
- added a new stream that listens to the opening of the sanner route
- added a new subscription called scanner to handle the opening of the
scanner route